### PR TITLE
Update heater state utility functions & body accessory to fix issues with getting/setting heater state

### DIFF
--- a/bodyAccessory.js
+++ b/bodyAccessory.js
@@ -122,7 +122,7 @@ PoolBodyAccessory.prototype.getThermoTargetState = function (callback) {
 };
 
 PoolBodyAccessory.prototype.setThermoTargetState = async function (newTargetState, callback) {
-  if (this.platform.LogLevel >= 3) this.log("Setting Body Target State", this.accessory.displayName, "to", newTargetState);
+  if (this.platform.LogLevel >= 3) this.log("Setting Body Target State", this.accessory.displayName, "to", utils.HK_mode(newTargetState, Characteristic));
 
   await this.platform.execute("setHeatMode", { id: this.bodyData.id, mode: utils.HK_Mode(newTargetState, Characteristic) })
  //  this.accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature).updateValue(newTargetState);

--- a/bodyAccessory.js
+++ b/bodyAccessory.js
@@ -125,7 +125,7 @@ PoolBodyAccessory.prototype.setThermoTargetState = async function (newTargetStat
   if (this.platform.LogLevel >= 3) this.log("Setting Body Target State", this.accessory.displayName, "to", newTargetState);
 
   await this.platform.execute("setHeatMode", { id: this.bodyData.id, mode: utils.HK_Mode(newTargetState, Characteristic) })
-  this.accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature).updateValue(newTargetState);
+ //  this.accessory.getService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature).updateValue(newTargetState);
 
   callback();
 };

--- a/utils.js
+++ b/utils.js
@@ -20,7 +20,7 @@ const F2C = (fahrenheit) => {
 
  const HeatingMode = (heatMode, myCharacteristic) => {
   Characteristic = myCharacteristic
-  if (heatMode.val==0)
+  if (heatMode.val==1)
     return Characteristic.TargetHeatingCoolingState.OFF
   else
     return Characteristic.TargetHeatingCoolingState.HEAT

--- a/utils.js
+++ b/utils.js
@@ -40,9 +40,9 @@ const HK_State = (HK_HeatStatus, myCharacteristic) => {
 const HK_Mode = (HK_HeatMode, myCharacteristic) => {
   Characteristic = myCharacteristic
   if (HK_HeatMode==Characteristic.TargetHeatingCoolingState.OFF) 
-      return 0
-  else 
       return 1
+  else 
+      return 2
 }
 
 exports.F2C = F2C


### PR DESCRIPTION
Two issues fixed here:
1. When setting heater state, the values in the utility functions were sending values of 0 and 1, instead of 1 and 2. I’m not sure why the nodejs pool controller API requires 1 and 2 for heater specifically, but 1 is off and 2 is heat. These changes update this so it works from Homekit. Before this, if you changes the heater state from Homekit it would turn off but never turn back on which isn’t useful if wanting to turn on heat from Homekit.
2. This fixes the logging issue with the incorrect value being set for the target temp state logged in the homebridge logs. This issue no longer appears with these changes. 